### PR TITLE
fix: Remove not needed operationTrait from tags duplication test

### DIFF
--- a/tests/asyncapi-2.0/Operation Trait Object/invalid-duplicate-tags.yaml
+++ b/tests/asyncapi-2.0/Operation Trait Object/invalid-duplicate-tags.yaml
@@ -16,7 +16,6 @@ channels:
               format: email
       traits:
         - $ref: "#/components/operationTraits/userSignedUpTrait"
-        - $ref: "#/components/operationTraits/userSignedUpDescTrait"
 
 components:
   operationTraits:
@@ -25,4 +24,3 @@ components:
         - name: user
           description: user signed up
         - name: user
-    userSignedUpDescTrait:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Remove not needed operationTrait from tags duplication test

Even though this YAML file is valid, it can cause issues in parsers if they do not apply traits properly, which is bad as this test case should not validate how others apply traits, but just if tags are duplicated. Anyway `userSignedUpDescTrait` is also irrelevant for this test case