### PR TITLE
fix: Incorrect message object examples

### DIFF
--- a/tests/asyncapi-2.0/Message Object/valid.yaml
+++ b/tests/asyncapi-2.0/Message Object/valid.yaml
@@ -43,7 +43,10 @@ channels:
               type: string
               format: email
         examples:
-          - one:
+          - payload:
               email: hello@foo.bar
-          - two:
+            headers:
+              correlationId: some id
+              applicationInstanceId: other id
+          - payload:
               email: bye@foo.bar

--- a/tests/asyncapi-2.0/Message Trait Object/valid.yaml
+++ b/tests/asyncapi-2.0/Message Trait Object/valid.yaml
@@ -48,7 +48,10 @@ components:
             description: Unique identifier for a given instance of the publishing application
             type: string
       examples:
-        - one:
+        - payload:
             email: hello@foo.bar
-        - two:
+          headers:
+            correlationId: some id
+            applicationInstanceId: other id
+        - payload:
             email: bye@foo.bar

--- a/tests/asyncapi-2.0/Reference Object/lib.yml
+++ b/tests/asyncapi-2.0/Reference Object/lib.yml
@@ -41,9 +41,12 @@ myMessage:
         type: string
         format: email
   examples:
-    - one:
+    - payload:
         email: hello@foo.bar
-    - two:
+      headers:
+        correlationId: some id
+        applicationInstanceId: other id
+    - payload:
         email: bye@foo.bar
 
 mySecurityScheme:


### PR DESCRIPTION
**Description**
Adjust message object examples facet to latest clarification made in the spec.

**Related issue(s)**
merged pull request in async: https://github.com/asyncapi/asyncapi/pull/453