### PR TITLE
docs: fix links in Markdown files

### DIFF
--- a/runner/go/README.md
+++ b/runner/go/README.md
@@ -6,7 +6,7 @@ Running tests produces JSON reports.
 
 A fine collection of AsyncAPI files can be composed each containing one/few AsyncAPI features to test those in isolation.
 
-Uses [AsyncAPI/tck](https://github.com/asyncapi/tck/tests/asyncapi-2.0) as a source of AsyncAPI for tests.
+Uses [AsyncAPI/tck](https://github.com/asyncapi/tck/tree/master/tests/asyncapi-2.0) as a source of AsyncAPI for tests.
 
 NOTE: If file name contains "invalid" parsing of it is expected to fail.
 

--- a/runner/java/README.md
+++ b/runner/java/README.md
@@ -6,7 +6,7 @@ Running tests produces JSON reports.
 
 A fine collection of AsyncAPI files can be composed each containing one/few AsyncAPI features to test those in isolation.
 
-Uses [AsyncAPI/tck](https://github.com/asyncapi/tck/tests/asyncapi-2.0) as a source of AsyncAPI for tests.
+Uses [AsyncAPI/tck](https://github.com/asyncapi/tck/tree/master/tests/asyncapi-2.0) as a source of AsyncAPI for tests.
 
 NOTE: If file name contains "invalid" parsing of it is expected to fail.
 

--- a/runner/js/README.md
+++ b/runner/js/README.md
@@ -6,7 +6,7 @@ Running tests produces JSON reports.
 
 A fine collection of AsyncAPI files can be composed each containing one/few AsyncAPI features to test those in isolation.
 
-Uses [AsyncAPI/tck](https://github.com/asyncapi/tck/tests/asyncapi-2.0/) as a source of AsyncAPI for tests.
+Uses [AsyncAPI/tck](https://github.com/asyncapi/tck/tree/master/tests/asyncapi-2.0) as a source of AsyncAPI for tests.
 
 NOTE: If file name contains "invalid" parsing of it is expected to fail.
 

--- a/runner/js/README.md
+++ b/runner/js/README.md
@@ -6,7 +6,7 @@ Running tests produces JSON reports.
 
 A fine collection of AsyncAPI files can be composed each containing one/few AsyncAPI features to test those in isolation.
 
-Uses [AsyncAPI/tck](https://github.com/asyncapi/tck/tests/asyncapi-2.0) as a source of AsyncAPI for tests.
+Uses [AsyncAPI/tck](https://github.com/asyncapi/tck/tests/asyncapi-2.0/) as a source of AsyncAPI for tests.
 
 NOTE: If file name contains "invalid" parsing of it is expected to fail.
 


### PR DESCRIPTION
#### Description
this PR is supposed to fix all the [dead links](https://github.com/asyncapi/tck/runs/6143295215?check_suite_focus=true) in markdown files across the repo.